### PR TITLE
minor typo fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Dictate text to the currently opened window (intended for use on pc)
 ## About
 After enabled "dictation mode", all text will be sent to the active application.
 
-TODO: without a PC, the message should be saved al plain text for later access, e.g. sent via mail or reminded at certain time
+TODO: without a PC, the message should be saved as plain text for later access, e.g. sent via mail or reminded at certain time
 
 ## Examples
 * "Begin dictation"


### PR DESCRIPTION
* changed "saved al plain text" to "saved as plain text"
    - assumed this was an error, as have seen same error other places, and have made it myself